### PR TITLE
Add unit tests for create assignment validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ javafx {
 dependencies {
     implementation 'io.github.mkpaz:atlantafx-base:2.0.1'
     implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 application {

--- a/src/test/java/com/gradetracker/controller/CreateAssignmentControllerTest.java
+++ b/src/test/java/com/gradetracker/controller/CreateAssignmentControllerTest.java
@@ -18,16 +18,14 @@ class CreateAssignmentControllerTest {
   // Testing plan item 1: valid assignment creation
   @Test
   void validAssignmentReturnsNull() {
-    String result = CreateAssignmentController.validate(
-        "Homework 1", "100", Collections.emptyList());
+    String result = CreateAssignmentController.validate("Homework 1", "100", Collections.emptyList());
     assertNull(result);
   }
 
   // Testing plan item 2a: no assignment title
   @Test
   void emptyTitleReturnsError() {
-    String result = CreateAssignmentController.validate(
-        "", "100", Collections.emptyList());
+    String result = CreateAssignmentController.validate("", "100", Collections.emptyList());
     assertEquals("Title is required.", result);
   }
 

--- a/src/test/java/com/gradetracker/controller/CreateAssignmentControllerTest.java
+++ b/src/test/java/com/gradetracker/controller/CreateAssignmentControllerTest.java
@@ -1,0 +1,36 @@
+package com.gradetracker.controller;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for CreateAssignmentController validation.
+ * Tests align with "Test Teacher Creates an Assignment" in the testing plan.
+ *
+ * @author Mikey Voss
+ * @since 2026-04-13
+ */
+class CreateAssignmentControllerTest {
+
+  // Testing plan item 1: valid assignment creation
+  @Test
+  void validAssignmentReturnsNull() {
+    String result = CreateAssignmentController.validate(
+        "Homework 1", "100", Collections.emptyList());
+    assertNull(result);
+  }
+
+  // Testing plan item 2a: no assignment title
+  @Test
+  void emptyTitleReturnsError() {
+    String result = CreateAssignmentController.validate(
+        "", "100", Collections.emptyList());
+    assertEquals("Title is required.", result);
+  }
+
+  // TODO: testing plan item 2b - no max grade
+  // TODO: testing plan item 3 - duplicate assignment name
+}


### PR DESCRIPTION
Refs #5

Adds JUnit 5 and two initial unit tests for `CreateAssignmentController.validate()`. Tests align with the "Test Teacher Creates an Assignment" section in the testing plan.

**Covered:** valid assignment creation (plan item 1), empty title rejection (plan item 2a)

**Still needed:** no max grade test (plan item 2b), duplicate name test (plan item 3), Teacher Enters Grades tests (issue #4)