### PR TITLE
Create User tests

### DIFF
--- a/src/test/java/com/gradetracker/controller/CreateUserControllerTest.java
+++ b/src/test/java/com/gradetracker/controller/CreateUserControllerTest.java
@@ -13,9 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class CreateUserControllerTest {
 
     @Test
-    void validUserReturnsNull() {
+    void testValidUserCreation() {
         String result = CreateUserController.validate(
-                "robert1",
+                "newstudent1",
                 "Robert",
                 "Mozzetti",
                 "Student",
@@ -28,52 +28,7 @@ class CreateUserControllerTest {
     }
 
     @Test
-    void blankUsernameReturnsError() {
-        String result = CreateUserController.validate(
-                "",
-                "Robert",
-                "Mozzetti",
-                "Student",
-                "password123",
-                "password123",
-                Collections.emptySet()
-        );
-
-        assertEquals("Username is required.", result);
-    }
-
-    @Test
-    void blankRoleReturnsError() {
-        String result = CreateUserController.validate(
-                "robert1",
-                "Robert",
-                "Mozzetti",
-                "",
-                "password123",
-                "password123",
-                Collections.emptySet()
-        );
-
-        assertEquals("Role is required.", result);
-    }
-
-    @Test
-    void mismatchedPasswordsReturnError() {
-        String result = CreateUserController.validate(
-                "robert1",
-                "Robert",
-                "Mozzetti",
-                "Student",
-                "password123",
-                "different123",
-                Collections.emptySet()
-        );
-
-        assertEquals("Passwords do not match.", result);
-    }
-
-    @Test
-    void duplicateUsernameReturnsError() {
+    void testDuplicateUsername() {
         String result = CreateUserController.validate(
                 "admin",
                 "Robert",
@@ -85,5 +40,31 @@ class CreateUserControllerTest {
         );
 
         assertEquals("That username is already taken.", result);
+    }
+
+    @Test
+    void testTwoUsersIdenticalPasswords() {
+        String firstResult = CreateUserController.validate(
+                "student1",
+                "Robert",
+                "Mozzetti",
+                "Student",
+                "samepassword123",
+                "samepassword123",
+                Collections.emptySet()
+        );
+
+        String secondResult = CreateUserController.validate(
+                "student2",
+                "Olga",
+                "Bradford",
+                "Student",
+                "samepassword123",
+                "samepassword123",
+                Set.of("student1")
+        );
+
+        assertNull(firstResult);
+        assertNull(secondResult);
     }
 }

--- a/src/test/java/com/gradetracker/controller/CreateUserControllerTest.java
+++ b/src/test/java/com/gradetracker/controller/CreateUserControllerTest.java
@@ -1,0 +1,7 @@
+package com.gradetracker.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CreateUserControllerTest {
+
+}

--- a/src/test/java/com/gradetracker/controller/CreateUserControllerTest.java
+++ b/src/test/java/com/gradetracker/controller/CreateUserControllerTest.java
@@ -1,7 +1,89 @@
 package com.gradetracker.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for CreateUserController validation.
+ */
 class CreateUserControllerTest {
 
+    @Test
+    void validUserReturnsNull() {
+        String result = CreateUserController.validate(
+                "robert1",
+                "Robert",
+                "Mozzetti",
+                "Student",
+                "password123",
+                "password123",
+                Collections.emptySet()
+        );
+
+        assertNull(result);
+    }
+
+    @Test
+    void blankUsernameReturnsError() {
+        String result = CreateUserController.validate(
+                "",
+                "Robert",
+                "Mozzetti",
+                "Student",
+                "password123",
+                "password123",
+                Collections.emptySet()
+        );
+
+        assertEquals("Username is required.", result);
+    }
+
+    @Test
+    void blankRoleReturnsError() {
+        String result = CreateUserController.validate(
+                "robert1",
+                "Robert",
+                "Mozzetti",
+                "",
+                "password123",
+                "password123",
+                Collections.emptySet()
+        );
+
+        assertEquals("Role is required.", result);
+    }
+
+    @Test
+    void mismatchedPasswordsReturnError() {
+        String result = CreateUserController.validate(
+                "robert1",
+                "Robert",
+                "Mozzetti",
+                "Student",
+                "password123",
+                "different123",
+                Collections.emptySet()
+        );
+
+        assertEquals("Passwords do not match.", result);
+    }
+
+    @Test
+    void duplicateUsernameReturnsError() {
+        String result = CreateUserController.validate(
+                "admin",
+                "Robert",
+                "Mozzetti",
+                "Admin",
+                "password123",
+                "password123",
+                Set.of("admin", "teacher1")
+        );
+
+        assertEquals("That username is already taken.", result);
+    }
 }


### PR DESCRIPTION
Refs #17 

Adds JUnit5 to `build.gradle` and has 3 tests outlined in the design document for the `CreateUserController.java` scene. Tests cover valid user creation, failed user creation with a duplicate username, and valid user creation with a duplicate password.