### PR TITLE
Add grade storage and scene-to-scene data passing

### DIFF
--- a/src/main/java/com/gradetracker/dao/GradeDao.java
+++ b/src/main/java/com/gradetracker/dao/GradeDao.java
@@ -1,0 +1,44 @@
+package com.gradetracker.dao;
+
+import com.gradetracker.model.Grade;
+import java.util.List;
+
+/**
+ * Data access interface for grades.
+ *
+ * @author Mikey Voss
+ * @since 2026-04-16
+ */
+public interface GradeDao {
+
+  /**
+   * Saves a grade and assigns it an id.
+   *
+   * @param grade the grade to save
+   */
+  void save(Grade grade);
+
+  /**
+   * Finds all grades submitted for a given assignment.
+   *
+   * @param assignmentId the assignment id to search by
+   * @return list of grades for that assignment
+   */
+  List<Grade> findByAssignmentId(int assignmentId);
+
+  /**
+   * Finds all grades across every assignment in a given class.
+   *
+   * @param classId the class id to search by
+   * @return list of grades in that class
+   */
+  List<Grade> findByClassId(int classId);
+
+  /**
+   * Finds all grades earned by a given student.
+   *
+   * @param studentId the student id to search by
+   * @return list of grades for that student
+   */
+  List<Grade> findByStudentId(int studentId);
+}

--- a/src/main/java/com/gradetracker/dao/SqliteGradeDao.java
+++ b/src/main/java/com/gradetracker/dao/SqliteGradeDao.java
@@ -1,0 +1,115 @@
+package com.gradetracker.dao;
+
+import com.gradetracker.model.Grade;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * SQLite implementation of GradeDao.
+ *
+ * @author Mikey Voss
+ * @since 2026-04-16
+ */
+public class SqliteGradeDao implements GradeDao {
+
+  @Override
+  public void save(Grade grade) {
+    String sql = "INSERT INTO grades (gradeValue, assignmentId, studentId) "
+        + "VALUES (?, ?, ?)";
+
+    try (Connection conn = DatabaseManager.getInstance().getConnection();
+        PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+      stmt.setDouble(1, grade.getGradeValue());
+      stmt.setInt(2, grade.getAssignmentId());
+      stmt.setInt(3, grade.getStudentId());
+      stmt.executeUpdate();
+
+      ResultSet keys = stmt.getGeneratedKeys();
+      if (keys.next()) {
+        grade.setId(keys.getInt(1));
+      }
+    } catch (SQLException e) {
+      System.err.println("Failed to save grade: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public List<Grade> findByAssignmentId(int assignmentId) {
+    String sql = "SELECT gradeId, gradeValue, assignmentId, studentId "
+        + "FROM grades WHERE assignmentId = ?";
+    List<Grade> results = new ArrayList<>();
+
+    try (Connection conn = DatabaseManager.getInstance().getConnection();
+        PreparedStatement stmt = conn.prepareStatement(sql)) {
+      stmt.setInt(1, assignmentId);
+      ResultSet rs = stmt.executeQuery();
+
+      while (rs.next()) {
+        results.add(mapRow(rs));
+      }
+    } catch (SQLException e) {
+      System.err.println("Failed to find grades: " + e.getMessage());
+    }
+
+    return results;
+  }
+
+  @Override
+  public List<Grade> findByClassId(int classId) {
+    String sql = "SELECT grades.gradeId, grades.gradeValue, grades.assignmentId, "
+        + "grades.studentId FROM grades "
+        + "JOIN assignments ON grades.assignmentId = assignments.assignmentId "
+        + "WHERE assignments.classId = ?";
+    List<Grade> results = new ArrayList<>();
+
+    try (Connection conn = DatabaseManager.getInstance().getConnection();
+        PreparedStatement stmt = conn.prepareStatement(sql)) {
+      stmt.setInt(1, classId);
+      ResultSet rs = stmt.executeQuery();
+
+      while (rs.next()) {
+        results.add(mapRow(rs));
+      }
+    } catch (SQLException e) {
+      System.err.println("Failed to find grades: " + e.getMessage());
+    }
+
+    return results;
+  }
+
+  @Override
+  public List<Grade> findByStudentId(int studentId) {
+    String sql = "SELECT gradeId, gradeValue, assignmentId, studentId "
+        + "FROM grades WHERE studentId = ?";
+    List<Grade> results = new ArrayList<>();
+
+    try (Connection conn = DatabaseManager.getInstance().getConnection();
+        PreparedStatement stmt = conn.prepareStatement(sql)) {
+      stmt.setInt(1, studentId);
+      ResultSet rs = stmt.executeQuery();
+
+      while (rs.next()) {
+        results.add(mapRow(rs));
+      }
+    } catch (SQLException e) {
+      System.err.println("Failed to find grades: " + e.getMessage());
+    }
+
+    return results;
+  }
+
+  private Grade mapRow(ResultSet rs) throws SQLException {
+    Grade g = new Grade(
+        rs.getDouble("gradeValue"),
+        rs.getInt("assignmentId"),
+        rs.getInt("studentId")
+    );
+    g.setId(rs.getInt("gradeId"));
+    return g;
+  }
+}

--- a/src/main/java/com/gradetracker/manager/SceneManager.java
+++ b/src/main/java/com/gradetracker/manager/SceneManager.java
@@ -6,6 +6,7 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Handles scene switching for application.
@@ -25,6 +26,30 @@ public class SceneManager {
     try {
       FXMLLoader loader = new FXMLLoader(getClass().getResource(fxmlFile));
       Parent root = loader.load();
+
+      Scene scene = new Scene(root, 500, 450);
+      stage.setScene(scene);
+      stage.setTitle(title);
+      stage.show();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load scene: " + fxmlFile, e);
+    }
+  }
+
+  /**
+   * Switches scenes and lets the caller initialize the loaded controller
+   * before the scene is shown. Useful for passing data like a classId
+   * into the next scene.
+   *
+   * @param fxmlFile path to the FXML file
+   * @param title the window title
+   * @param controllerSetup receives the loaded controller
+   */
+  public void switchScene(String fxmlFile, String title, Consumer<Object> controllerSetup) {
+    try {
+      FXMLLoader loader = new FXMLLoader(getClass().getResource(fxmlFile));
+      Parent root = loader.load();
+      controllerSetup.accept(loader.getController());
 
       Scene scene = new Scene(root, 500, 450);
       stage.setScene(scene);

--- a/src/main/java/com/gradetracker/manager/SceneManager.java
+++ b/src/main/java/com/gradetracker/manager/SceneManager.java
@@ -23,17 +23,7 @@ public class SceneManager {
   }
 
   public void switchScene(String fxmlFile, String title) {
-    try {
-      FXMLLoader loader = new FXMLLoader(getClass().getResource(fxmlFile));
-      Parent root = loader.load();
-
-      Scene scene = new Scene(root, 500, 450);
-      stage.setScene(scene);
-      stage.setTitle(title);
-      stage.show();
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to load scene: " + fxmlFile, e);
-    }
+    switchScene(fxmlFile, title, c -> {});
   }
 
   /**

--- a/src/main/java/com/gradetracker/model/Grade.java
+++ b/src/main/java/com/gradetracker/model/Grade.java
@@ -1,0 +1,48 @@
+package com.gradetracker.model;
+
+/**
+ * Represents a grade for a student on an assignment.
+ *
+ * @author Mikey Voss
+ * @since 2026-04-16
+ */
+public class Grade {
+
+  private int id;
+  private double gradeValue;
+  private int assignmentId;
+  private int studentId;
+
+  /**
+   * Creates a new grade.
+   *
+   * @param gradeValue the score value
+   * @param assignmentId id of the assignment this grade belongs to
+   * @param studentId id of the student who earned the grade
+   */
+  public Grade(double gradeValue, int assignmentId, int studentId) {
+    this.gradeValue = gradeValue;
+    this.assignmentId = assignmentId;
+    this.studentId = studentId;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public double getGradeValue() {
+    return gradeValue;
+  }
+
+  public int getAssignmentId() {
+    return assignmentId;
+  }
+
+  public int getStudentId() {
+    return studentId;
+  }
+}


### PR DESCRIPTION
Refs #4

Foundation for the assignment-view grading screen. Two pieces: database code for saving and loading grades, and a way for one scene to hand data (like a class ID) to the next scene during navigation.

## Summary

- `Grade` model, `GradeDao` interface, and `SqliteGradeDao` implementation. Teachers can save a grade; any screen can look up grades by assignment, by class, or by student.
- `SceneManager.switchScene` gets an optional third argument: a setup function that configures the loaded controller right before the scene shows. The assignment view will use this to receive the class and assignment it's grading.
- The two-argument `switchScene` still works the same way; it now calls the new version internally instead of duplicating the FXML load logic.

## Still Needed

- Assignment view FXML and controller (rest of #4)
- Wire Create Assignment back button through the new scene switch
- Unit tests (issue #5)