### PR TITLE
Add assignment view scene for grading

### DIFF
--- a/src/main/java/com/gradetracker/controller/AssignmentViewController.java
+++ b/src/main/java/com/gradetracker/controller/AssignmentViewController.java
@@ -85,10 +85,27 @@ public class AssignmentViewController {
   @FXML
   private void initialize() {
     scoreTable.setItems(rows);
+    scoreTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
     studentColumn.setCellValueFactory(cell ->
         new SimpleStringProperty(cell.getValue().getStudentName()));
+    studentColumn.setCellFactory(column -> new DividerCell());
     scoreColumn.setCellValueFactory(cell -> cell.getValue().scoreTextProperty());
     scoreColumn.setCellFactory(column -> new LiveTextFieldCell());
+  }
+
+  // Plain text cell with a right border so the Student column reads as
+  // visually separated from the Score column.
+  private static class DividerCell extends TableCell<StudentScoreRow, String> {
+    DividerCell() {
+      setStyle("-fx-border-color: transparent -color-border-default transparent transparent;"
+          + " -fx-border-width: 0 1 0 0;");
+    }
+
+    @Override
+    protected void updateItem(String item, boolean empty) {
+      super.updateItem(item, empty);
+      setText(empty ? null : item);
+    }
   }
 
   /**

--- a/src/main/java/com/gradetracker/controller/AssignmentViewController.java
+++ b/src/main/java/com/gradetracker/controller/AssignmentViewController.java
@@ -246,11 +246,6 @@ public class AssignmentViewController {
     loadStudentRows();
   }
 
-  @FXML
-  private void handleBack() {
-    // TODO: hook up Back to return to the class view once SPA nav supports it
-  }
-
   private void setStatus(String message, boolean isError) {
     statusLabel.setStyle(isError ? "-fx-text-fill: red;" : "-fx-text-fill: green;");
     statusLabel.setText(message);

--- a/src/main/java/com/gradetracker/controller/AssignmentViewController.java
+++ b/src/main/java/com/gradetracker/controller/AssignmentViewController.java
@@ -1,0 +1,241 @@
+package com.gradetracker.controller;
+
+import com.gradetracker.dao.ClassDao;
+import com.gradetracker.dao.GradeDao;
+import com.gradetracker.dao.SqliteClassDao;
+import com.gradetracker.dao.SqliteGradeDao;
+import com.gradetracker.model.Assignment;
+import com.gradetracker.model.Grade;
+import com.gradetracker.model.User;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+
+/**
+ * Controller for the grade assignment scene. Displays the assignment and
+ * a table of enrolled students with an editable score per row.
+ *
+ * @author Mikey Voss
+ * @since 2026-04-18
+ */
+public class AssignmentViewController {
+
+  @FXML
+  private Label titleLabel;
+
+  @FXML
+  private Label descriptionLabel;
+
+  @FXML
+  private Label dueDateLabel;
+
+  @FXML
+  private Label maxGradeLabel;
+
+  @FXML
+  private TableView<StudentScoreRow> scoreTable;
+
+  @FXML
+  private TableColumn<StudentScoreRow, String> studentColumn;
+
+  @FXML
+  private TableColumn<StudentScoreRow, String> scoreColumn;
+
+  @FXML
+  private Button submitButton;
+
+  @FXML
+  private Label statusLabel;
+
+  private final ObservableList<StudentScoreRow> rows = FXCollections.observableArrayList();
+  private GradeDao gradeDao = new SqliteGradeDao();
+  private ClassDao classDao = new SqliteClassDao();
+  private Assignment assignment;
+
+  /**
+   * Sets the assignment shown in this view and refreshes the student table.
+   *
+   * @param assignment assignment to grade
+   */
+  public void setAssignment(Assignment assignment) {
+    this.assignment = assignment;
+    populateFields();
+  }
+
+  void setGradeDao(GradeDao gradeDao) {
+    this.gradeDao = gradeDao;
+  }
+
+  void setClassDao(ClassDao classDao) {
+    this.classDao = classDao;
+  }
+
+  @FXML
+  private void initialize() {
+    scoreTable.setItems(rows);
+    studentColumn.setCellValueFactory(cell ->
+        new SimpleStringProperty(cell.getValue().getStudentName()));
+    scoreColumn.setCellValueFactory(cell -> cell.getValue().scoreTextProperty());
+    scoreColumn.setCellFactory(column -> new LiveTextFieldCell());
+  }
+
+  /**
+   * A TableCell that keeps an always-visible TextField so users can type
+   * across rows without re-entering edit mode. Edits write through to the
+   * row model.
+   */
+  private static class LiveTextFieldCell extends TableCell<StudentScoreRow, String> {
+    private final TextField field = new TextField();
+    private StudentScoreRow boundRow;
+
+    LiveTextFieldCell() {
+      field.setMaxWidth(Double.MAX_VALUE);
+      field.textProperty().addListener((obs, oldV, newV) -> {
+        if (boundRow != null) {
+          boundRow.setScoreText(newV);
+        }
+      });
+    }
+
+    @Override
+    protected void updateItem(String item, boolean empty) {
+      super.updateItem(item, empty);
+      TableRow<StudentScoreRow> row = getTableRow();
+      if (empty || row == null || row.getItem() == null) {
+        boundRow = null;
+        setGraphic(null);
+        return;
+      }
+      rebind(row.getItem(), item == null ? "" : item);
+    }
+
+    // Briefly clears boundRow while refilling the TextField so the
+    // textProperty listener does not treat the refill as a user edit.
+    private void rebind(StudentScoreRow row, String current) {
+      boundRow = null;
+      if (!field.getText().equals(current)) {
+        field.setText(current);
+      }
+      boundRow = row;
+      setGraphic(field);
+      setText(null);
+    }
+  }
+
+  /**
+   * Validates a single grade entry against the assignment's max grade.
+   * A blank entry is treated as "no grade entered" and returns null.
+   *
+   * @param gradeText raw score text from a row
+   * @param maxGrade max grade allowed for this assignment
+   * @return error message if invalid, null if valid or blank
+   */
+  static String validate(String gradeText, double maxGrade) {
+    if (gradeText == null || gradeText.isBlank()) {
+      return null;
+    }
+    double grade;
+    try {
+      grade = Double.parseDouble(gradeText);
+    } catch (NumberFormatException e) {
+      return "Grade must be a number.";
+    }
+    if (grade < 0) {
+      return "Grade cannot be negative.";
+    }
+    if (grade > maxGrade) {
+      return "Grade cannot exceed max grade of " + maxGrade + ".";
+    }
+    return null;
+  }
+
+  private void populateFields() {
+    if (assignment == null) {
+      titleLabel.setText("No assignment selected");
+      descriptionLabel.setText("");
+      dueDateLabel.setText("");
+      maxGradeLabel.setText("");
+      rows.clear();
+      submitButton.setDisable(true);
+      return;
+    }
+    titleLabel.setText(assignment.getTitle());
+    descriptionLabel.setText(assignment.getDescription());
+    dueDateLabel.setText(
+        assignment.getDueDate() == null ? "" : assignment.getDueDate().toString());
+    maxGradeLabel.setText(String.valueOf(assignment.getMaxGrade()));
+    submitButton.setDisable(false);
+    loadStudentRows();
+  }
+
+  private void loadStudentRows() {
+    List<User> students = classDao.findEnrolledStudents(assignment.getClassId());
+    List<Grade> existingGrades = gradeDao.findByAssignmentId(assignment.getId());
+
+    Map<Integer, Double> latestByStudent = new HashMap<>();
+    for (Grade g : existingGrades) {
+      latestByStudent.put(g.getStudentId(), g.getGradeValue());
+    }
+
+    List<StudentScoreRow> built = new ArrayList<>();
+    for (User student : students) {
+      Double existing = latestByStudent.get(student.getUserId());
+      built.add(new StudentScoreRow(
+          student.getUserId(),
+          student.getUsername(),
+          existing == null ? "" : String.valueOf(existing)
+      ));
+    }
+
+    rows.setAll(built);
+  }
+
+  @FXML
+  private void handleSubmit() {
+    if (assignment == null) {
+      setStatus("No assignment loaded.", true);
+      return;
+    }
+    List<Grade> toSave = new ArrayList<>();
+    for (StudentScoreRow row : rows) {
+      String text = row.getScoreText();
+      String error = validate(text, assignment.getMaxGrade());
+      if (error != null) {
+        setStatus(error + " (" + row.getStudentName() + ")", true);
+        return;
+      }
+      if (text == null || text.isBlank()) {
+        continue;
+      }
+      toSave.add(new Grade(
+          Double.parseDouble(text), assignment.getId(), row.getStudentId()));
+    }
+    for (Grade grade : toSave) {
+      gradeDao.save(grade);
+    }
+    setStatus("Saved " + toSave.size() + " grade(s).", false);
+    loadStudentRows();
+  }
+
+  @FXML
+  private void handleBack() {
+    // TODO: hook up Back to return to the class view once SPA nav supports it
+  }
+
+  private void setStatus(String message, boolean isError) {
+    statusLabel.setStyle(isError ? "-fx-text-fill: red;" : "-fx-text-fill: green;");
+    statusLabel.setText(message);
+  }
+}

--- a/src/main/java/com/gradetracker/controller/CreateAssignmentController.java
+++ b/src/main/java/com/gradetracker/controller/CreateAssignmentController.java
@@ -92,8 +92,4 @@ public class CreateAssignmentController {
     errorLabel.setText("Assignment created.");
   }
 
-  @FXML
-  private void handleBack() {
-    // TODO: navigate back to class view
-  }
 }

--- a/src/main/java/com/gradetracker/controller/StudentScoreRow.java
+++ b/src/main/java/com/gradetracker/controller/StudentScoreRow.java
@@ -1,0 +1,61 @@
+package com.gradetracker.controller;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+/**
+ * One row in the Grade Assignment table: a student and their editable score.
+ *
+ * @author Mikey Voss
+ * @since 2026-04-18
+ */
+public class StudentScoreRow {
+
+  private final int studentId;
+  private final String studentName;
+  private final StringProperty scoreText;
+
+  /**
+   * Creates a row for one enrolled student.
+   *
+   * @param studentId the student's user id
+   * @param studentName display name shown in the Student column
+   * @param initialScore pre-filled score text (empty string if not yet graded)
+   */
+  public StudentScoreRow(int studentId, String studentName, String initialScore) {
+    this.studentId = studentId;
+    this.studentName = studentName;
+    this.scoreText = new SimpleStringProperty(initialScore == null ? "" : initialScore);
+  }
+
+  public int getStudentId() {
+    return studentId;
+  }
+
+  public String getStudentName() {
+    return studentName;
+  }
+
+  public String getScoreText() {
+    return scoreText.get();
+  }
+
+  /**
+   * Updates the score text shown in the table.
+   *
+   * @param value new score text
+   */
+  public void setScoreText(String value) {
+    scoreText.set(value);
+  }
+
+  /**
+   * Exposes the score as an observable property so the TableView cell can
+   * bind to it directly.
+   *
+   * @return the score text property
+   */
+  public StringProperty scoreTextProperty() {
+    return scoreText;
+  }
+}

--- a/src/main/resources/fxml/assignment-view.fxml
+++ b/src/main/resources/fxml/assignment-view.fxml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<!--
+
+@author Mikey Voss
+@since 2026-04-18
+-->
+<VBox alignment="TOP_LEFT" spacing="12.0"
+  xmlns="http://javafx.com/javafx/21"
+  xmlns:fx="http://javafx.com/fxml/1"
+  fx:controller="com.gradetracker.controller.AssignmentViewController">
+
+  <padding>
+    <Insets top="20.0" right="20.0" bottom="20.0" left="20.0"/>
+  </padding>
+
+  <Label text="Grade Assignment"
+    style="-fx-font-size: 18px; -fx-font-weight: bold;" />
+
+  <Label fx:id="titleLabel" text="Title"
+    style="-fx-font-size: 16px; -fx-font-weight: bold;" />
+
+  <Label fx:id="descriptionLabel" text="Description" wrapText="true" />
+
+  <HBox spacing="20.0">
+    <HBox spacing="6.0">
+      <Label text="Due:" style="-fx-font-weight: bold;" />
+      <Label fx:id="dueDateLabel" text="" />
+    </HBox>
+    <HBox spacing="6.0">
+      <Label text="Max Grade:" style="-fx-font-weight: bold;" />
+      <Label fx:id="maxGradeLabel" text="" />
+    </HBox>
+  </HBox>
+
+  <Separator />
+
+  <Label text="Students" style="-fx-font-weight: bold;" />
+
+  <TableView fx:id="scoreTable" editable="true" prefHeight="280.0">
+    <columns>
+      <TableColumn fx:id="studentColumn" text="Student" prefWidth="300.0" />
+      <TableColumn fx:id="scoreColumn" text="Score" prefWidth="150.0" editable="true" />
+    </columns>
+  </TableView>
+
+  <HBox spacing="10.0">
+    <Button text="Back" onAction="#handleBack" />
+    <Button fx:id="submitButton" text="Submit"
+      onAction="#handleSubmit" styleClass="success" />
+  </HBox>
+
+  <Label fx:id="statusLabel" text="" />
+
+</VBox>

--- a/src/main/resources/fxml/assignment-view.fxml
+++ b/src/main/resources/fxml/assignment-view.fxml
@@ -53,8 +53,7 @@
     </columns>
   </TableView>
 
-  <HBox spacing="10.0">
-    <Button text="Back" onAction="#handleBack" />
+  <HBox spacing="10.0" alignment="CENTER">
     <Button fx:id="submitButton" text="Submit"
       onAction="#handleSubmit" styleClass="success" />
   </HBox>

--- a/src/main/resources/fxml/create-assignment.fxml
+++ b/src/main/resources/fxml/create-assignment.fxml
@@ -36,7 +36,6 @@
   <TextField fx:id="maxGradeField" promptText="Max Grade" />
 
   <HBox spacing="10.0" alignment="CENTER">
-    <Button text="Back" onAction="#handleBack" />
     <Button text="Submit" onAction="#handleSubmit" styleClass="success" />
   </HBox>
 


### PR DESCRIPTION
Refs #4

Rest of the Assignment View scene work from #38. Teachers open an assignment, see a table of enrolled students with a score field per row, and submit to save all the grades at once.

## Summary

- New scene `assignment-view.fxml` + `AssignmentViewController` that loads the assignment's roster and any existing grades, and persists new grades through `GradeDao`.
- Score cells use an always-visible text field so teachers can tab across rows without re-entering edit mode, then submit at the end.
- Validation rejects non-numeric, negative, and over-max grade values per row. Blank rows get skipped.

## Still Needed

- Dashboard card click to open the scene (waits on the teacher dashboard build-out).
- Back button navigation to the class view (waits on that scene to exist).

## Screenshots
<img width="1778" height="1570" alt="vP-013532" src="https://github.com/user-attachments/assets/a5d15877-0b46-4aee-b396-1f91abba1463" />