### PR TITLE
Wrap up Create Assignment and Assignment View follow-ups

### DIFF
--- a/src/main/java/com/gradetracker/GradeTrackerApp.java
+++ b/src/main/java/com/gradetracker/GradeTrackerApp.java
@@ -33,7 +33,6 @@ public class GradeTrackerApp extends Application {
     stage.setX((screen.getWidth() - width) / 2);
     stage.setY((screen.getHeight() - height) / 2);
 
-    // TODO: change to login.fxml once login scene is wired up
     SceneManager sceneManager = new SceneManager(stage);
     sceneManager.switchScene("/fxml/login.fxml", "Grade Tracker");
   }

--- a/src/main/java/com/gradetracker/controller/CreateAssignmentController.java
+++ b/src/main/java/com/gradetracker/controller/CreateAssignmentController.java
@@ -35,8 +35,7 @@ public class CreateAssignmentController {
   private Label errorLabel;
 
   private AssignmentDao dao = new SqliteAssignmentDao();
-  // TODO: pass classId from class view once navigation supports data passing
-  private int classId = 1;
+  private int classId;
 
   /**
    * Passing classId to the scene

--- a/src/main/java/com/gradetracker/controller/StudentClassController.java
+++ b/src/main/java/com/gradetracker/controller/StudentClassController.java
@@ -275,6 +275,7 @@ public class StudentClassController {
       popup.initModality(Modality.APPLICATION_MODAL);
       popup.setScene(new Scene(root, width, -1));
       popup.showAndWait();
+      getClassData();
     } catch (IOException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
Closes #3
Closes #4

## Summary

- `CreateAssignmentController` drops the `classId = 1` fallback. `ClassCardController` already passes the real class in, so the default was masking setup errors.
- Grading popup triggers a class view refresh when it closes. Re-queries assignments and grades so the class view stays in sync with the database.
- Deleted a stale `login.fxml` TODO in `GradeTrackerApp` that pointed to work already done.
